### PR TITLE
Check response is JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiny-fetch-json",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiny-fetch-json",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-fetch-json",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Tiny wrapper around Fetch to query JSON APIs more easily",
   "keywords": [
     "api",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "src"
   ],
   "main": "src/index.js",
-  "repository": "hemilabs/tiny-fetch-json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hemilabs/tiny-fetch-json.git"
+  },
   "scripts": {
     "ci-checks": "npm run lint && npm run format:check && npm run deps:check",
     "deps:check": "knip",
@@ -39,7 +42,7 @@
     "prettier": "^3.5.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=8.3"
   },
   "types": "src/index.d.ts"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,12 @@ async function fetchJson(resource, options = {}) {
   if (!res.ok) {
     throw new Error(`Failed to fetch JSON: ${res.status} ${res.statusText}`);
   }
+
+  const contentType = res.headers.get("content-type");
+  if (!contentType || !contentType.includes("application/json")) {
+    throw new Error("Response is not JSON");
+  }
+
   return res.json();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function fetchJson(resource, options = {}) {
   }
 
   const contentType = res.headers.get("content-type");
-  if (!contentType || !contentType.includes("application/json")) {
+  if (!contentType || !contentType.toLowerCase().includes("application/json")) {
     throw new Error("Response is not JSON");
   }
 

--- a/test/src.index.test.js
+++ b/test/src.index.test.js
@@ -11,6 +11,12 @@ function mockFetch(response, options = {}) {
       return Promise.reject(options.rejectWith || new Error("Network error"));
     }
     return Promise.resolve({
+      headers: {
+        get: (header) =>
+          header.toLowerCase() === "content-type"
+            ? options.contentType || "application/json"
+            : null,
+      },
       json: () =>
         options.invalidJson
           ? Promise.reject(new Error("Invalid JSON"))
@@ -68,6 +74,18 @@ test("Throws if the response is invalid JSON", async function () {
       await assert.rejects(
         () => fetchJson("https://api.example.com/badjson"),
         /Invalid JSON/,
+      );
+    },
+  );
+});
+
+test("Throws if the response is not a JSON", async function () {
+  await withMockedFetch(
+    mockFetch(null, { contentType: "text/html" }),
+    async function () {
+      await assert.rejects(
+        () => fetchJson("https://api.example.com/badjson"),
+        /Response is not JSON/,
       );
     },
   );


### PR DESCRIPTION
This PR adds a check to ensure the response is JSON before calling `res.json()`. This provides not only a better error handling but prevents JSON-like responses to be parsed anyway.