### PR TITLE
Fix minimum node version required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiny-fetch-json",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiny-fetch-json",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
@@ -22,7 +22,7 @@
         "prettier": "^3.5.3"
       },
       "engines": {
-        "node": ">=8.3"
+        "node": ">=18"
       }
     },
     "node_modules/@altano/repository-tools": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-fetch-json",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tiny wrapper around Fetch to query JSON APIs more easily",
   "keywords": [
     "api",
@@ -42,7 +42,7 @@
     "prettier": "^3.5.3"
   },
   "engines": {
-    "node": ">=8.3"
+    "node": ">=18"
   },
   "types": "src/index.d.ts"
 }


### PR DESCRIPTION
Fixes a silly mistake that went through in #2.

Note: The Fetch API was stable starting with Node 18.